### PR TITLE
Docs: clarify relationship to categorical book

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contributor workflow and local build guidance are documented in [`CONTRIBUTING.m
 - The related Japanese book is `圏論によるAIエージェント時代の合成的ソフトウェア設計` (`categorical-software-design-book`).
 - The two books share themes and some terminology, but they are not legacy/current versions and are not simple translations of each other.
 - Start with this repository if you want the English-first canonical manuscript and the current composition centered on compositional design for agentic systems.
-- Start with the Japanese book if you want a Japanese reader-facing book focused on AI-agent-era design artifacts, Context Pack usage, and GitHub/CI-oriented guidance.
+- Start with the Japanese book if you want a Japanese reader-facing book focused on design artifacts for the AI agent era, Context Pack usage, and GitHub/CI-oriented guidance.
 - Related Japanese book:
   - Public site: https://itdojp.github.io/categorical-software-design-book/
   - Repository: https://github.com/itdojp/categorical-software-design-book

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ A practical guide to designing AI-assisted software systems with composition, di
 - `圏論によるAIエージェント時代の合成的ソフトウェア設計` (`categorical-software-design-book`) is a related but independent Japanese book.
 - This English book is not a rename or replacement for that Japanese book.
 - Start here if you want the English-first canonical manuscript and the current part-based composition.
-- Start with the Japanese book if you want a Japanese reader-facing guide focused on AI-agent-era software design artifacts, Context Pack usage, and GitHub/CI-oriented guidance.
+- Start with the Japanese book if you want a Japanese reader-facing guide focused on software design artifacts for the AI agent era, Context Pack usage, and GitHub/CI-oriented guidance.
 - Related Japanese book: [Public site](https://itdojp.github.io/categorical-software-design-book/) / [Repository](https://github.com/itdojp/categorical-software-design-book)
 
 ## What You Will Learn


### PR DESCRIPTION
## Overview
- clarify that `composable-software-design-book` is an independent English book
- distinguish internal `manuscript/ja/` drafts from the separately published Japanese book
- add reciprocal guidance to the related Japanese book `categorical-software-design-book`

## Changed files
- `README.md`
- `index.md`

## Verification
- `bundle exec jekyll build`
- built top page check for the related Japanese book note and non-replacement wording
