### PR TITLE
Add Phase 5 practical review gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+# Pull Request
+
+## Related Issue
+
+- Resolves: <!-- issue URL or number -->
+
+## Summary
+
+- <!-- Summarize content, validation, and review evidence. -->
+
+## Review Completion Gate
+
+- [ ] The PR explains the practical review scope and content-audit judgment.
+- [ ] Reader-facing changes preserve the English canonical source.
+- [ ] Japanese drafts from `manuscript/ja/` are not published as-is.
+- [ ] Theory-to-practice claims name preserved structure and boundaries.
+- [ ] Theory-to-practice claims name verification evidence and known limits.
+- [ ] Related-book responsibility boundaries remain explicit.
+- [ ] GitHub Copilot review was requested.
+- [ ] Review body, inline comments, and suggestions were all checked.
+- [ ] Actionable comments were fixed or answered with a non-change rationale.
+- [ ] Unresolved review threads are confirmed to be 0 before merge.
+
+## Verification
+
+- [ ] `npm run qa`
+- [ ] `npm run build:native`
+- [ ] `npm run validate-deploy`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 ## Review Completion Gate
 
-- [ ] The PR explains the practical review scope and content-audit judgment.
+- [ ] The PR explains the practical-connection scope and audit judgment.
 - [ ] Reader-facing changes preserve the English canonical source.
 - [ ] Japanese drafts from `manuscript/ja/` are not published as-is.
 - [ ] Theory-to-practice claims name preserved structure and boundaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Phase 5 practical-connection review gates in `README.md` and the public landing page.
+- Editorial checks for theory-to-practice mapping, evidence boundaries, non-applicability conditions, and the related-book responsibility boundary.
+- Pull request template items for related issues, GitHub Copilot review, unresolved thread checks, and repository validation evidence.
+
+### Changed
+
+- Appendix D now states how transfer cases should record preserved structure, drift detection, and the limits of a compositional analogy.
+
 ## [0.1.0-rc1] - 2026-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Japanese drafts under `manuscript/ja/` are working inputs and are not published.
 Those internal drafts are distinct from the separately published Japanese book in `categorical-software-design-book`.
 Contributor workflow and local build guidance are documented in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+## Phase 5 Practical-Connection Review Gate
+
+Use this gate when reviewing changes that connect composition, category-theoretic vocabulary, architecture examples, interfaces, types, tests, or AI-assisted delivery workflows.
+Each practical claim should name the structure being preserved, the artifact or interface boundary that carries it, the check or evidence that would detect drift, and the limitation that prevents overgeneralizing the theory.
+If a chapter cannot point to those four items, keep the claim as motivation rather than as an implementation rule.
+Design examples should also state when composition is the wrong abstraction, such as when a boundary is unstable, an effect cannot be isolated, or the evidence model would be weaker than an ordinary checklist.
+
+Reviewers should verify the following before merging a content change:
+
+- The formal term being used has a visible engineering counterpart in the manuscript, running example, or supporting artifact.
+- The example identifies the preserved invariant, the artifact boundary, and the verification or review evidence.
+- Trade-offs and non-applicability conditions are stated when the method would otherwise look universally valid.
+- The boundary with `categorical-software-design-book` remains explicit: this English book owns the English-first compositional method for agentic systems, while the Japanese book owns its Japanese reader-facing design-artifact and Context Pack workflow emphasis.
+- GitHub Copilot review feedback, inline comments, and suggestions are all addressed or explicitly answered, with zero unresolved review threads before merge.
+
 ## Relationship to the related Japanese book
 
 - This repository is an independent English book.

--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ Start with the front matter and the Introduction if you want the book's main pro
 Use the [minimal example](examples/minimal/policy-gated-change-review/README/) after that first pass to see the smallest reusable chain of objects, morphisms, and a diagram.
 Continue with the [common running example](examples/common/policy-gated-change-review/README/) when you want to inspect the specification, design, verification, and implementation artifacts that support the chapter arguments.
 
-## Phase 5 Practical Review Gate
+## Phase 5 Practical-Connection Review Gate
 
 This book should not ask readers to accept a category-theoretic word as practical guidance unless the manuscript also shows what the word preserves in engineering terms.
 For each revised example, reviewer prompt, or architecture claim, check four things: the preserved structure, the artifact or interface boundary, the evidence that would reveal drift, and the limit of the abstraction.

--- a/index.md
+++ b/index.md
@@ -59,6 +59,17 @@ Start with the front matter and the Introduction if you want the book's main pro
 Use the [minimal example](examples/minimal/policy-gated-change-review/README/) after that first pass to see the smallest reusable chain of objects, morphisms, and a diagram.
 Continue with the [common running example](examples/common/policy-gated-change-review/README/) when you want to inspect the specification, design, verification, and implementation artifacts that support the chapter arguments.
 
+## Phase 5 Practical Review Gate
+
+This book should not ask readers to accept a category-theoretic word as practical guidance unless the manuscript also shows what the word preserves in engineering terms.
+For each revised example, reviewer prompt, or architecture claim, check four things: the preserved structure, the artifact or interface boundary, the evidence that would reveal drift, and the limit of the abstraction.
+When those four items are absent, the text should present the idea as intuition rather than as an implementation rule.
+When those four items are present, the text should still identify cases where ordinary engineering review is better than forcing a compositional model.
+
+This gate also protects the relationship with the related Japanese book.
+`categorical-software-design-book` remains a related but independent Japanese reader-facing book with a stronger emphasis on design artifacts, Context Pack use, and GitHub/CI workflows.
+This English book remains the canonical English manuscript for compositional design in agentic systems, so cross-references must clarify responsibility rather than imply a rename, replacement, or translation chain.
+
 ## Front Matter
 
 - [Preface](src/additional/preface/)

--- a/project-management/editorial-checklist.md
+++ b/project-management/editorial-checklist.md
@@ -45,3 +45,13 @@
 - Notes and Further Reading are present in drafted public chapters.
 - Running example linkage uses the canonical `policy-gated-change-review` example and points readers to the relevant artifact or example landing page.
 - QA and translation validation scripts still pass after the edit set.
+
+## Phase 5 Practical-Connection Review Checks
+
+- A theory-to-practice claim names the preserved structure or invariant before it asks the reader to trust a formal term.
+- The claim points to a concrete artifact boundary, interface, type, checklist, test, trace, or evidence bundle that would carry the preserved structure.
+- The revision states how a reviewer would detect drift, such as by checking a diagram claim, traceability row, schema field, test result, or review prompt.
+- The revision states at least one trade-off, precondition, or non-applicability condition when the abstraction could otherwise be read as universal.
+- Examples that discuss AI-assisted delivery distinguish delegated drafting, policy evaluation, human approval, effectful execution, and emitted evidence.
+- Changes that mention `categorical-software-design-book` preserve the independent-book boundary: this repository owns the English-first compositional method for agentic systems, while the Japanese book owns its Japanese reader-facing design-artifact and Context Pack workflow emphasis.
+- Pull requests that change reader-facing content record the review evidence, pass repository QA, receive GitHub Copilot review, and reach zero unresolved review threads before merge.

--- a/project-management/editorial-checklist.md
+++ b/project-management/editorial-checklist.md
@@ -46,7 +46,7 @@
 - Running example linkage uses the canonical `policy-gated-change-review` example and points readers to the relevant artifact or example landing page.
 - QA and translation validation scripts still pass after the edit set.
 
-## Phase 5 Practical-Connection Review Checks
+## Phase 5 Practical-Connection Review Gate
 
 - A theory-to-practice claim names the preserved structure or invariant before it asks the reader to trust a formal term.
 - The claim points to a concrete artifact boundary, interface, type, checklist, test, trace, or evidence bundle that would carry the preserved structure.

--- a/src/appendices/appendix-d.md
+++ b/src/appendices/appendix-d.md
@@ -22,6 +22,10 @@ The point is to show which invariants, boundaries, and evidence obligations surv
 Use the mapping tables as compact translation aids.
 If one domain cannot support an explicit object boundary, one stable morphism chain, one core diagram claim, one effect boundary, and one approval-evidence model, the method will expose that weakness quickly.
 
+Before transferring the method, reviewers should record what is preserved, what carries that preservation, how drift would be detected, and where the analogy stops.
+A transfer case is not stronger because every row resembles category-theory vocabulary.
+It is stronger when the domain exposes an auditable artifact boundary, a practical verification signal, and a clear stop line for cases where composition would hide operational risk.
+
 ## Transfer case 1. Deployment approval pipeline
 
 This caselet maps the running example into a staged production deployment workflow where release automation proposes a rollout but humans retain final release authority.
@@ -84,3 +88,5 @@ What changes is the surrounding control vocabulary and the lifetime of the evide
 The method generalizes because the domain nouns may change while the architectural obligations stay recognizable.
 Each domain still needs stable objects, explicit transformations, one named approval boundary, one effect boundary, and evidence that can be traced back to a governing claim.
 That is the invariant Chapter 10 relies on when it argues that the running example is canonical but not exclusive.
+The method should not be applied when the domain cannot define those obligations without inventing evidence after the fact.
+In that case, a conventional checklist, incident playbook, or risk register may be the safer artifact until the boundary and evidence model are stable enough to compose.


### PR DESCRIPTION
## Related Issue

- Resolves: https://github.com/itdojp/composable-software-design-book/issues/77
- Parent roadmap: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/153
- Phase 5 management: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/158

## Summary

- Added Phase 5 practical-connection review gates to README and the public landing page.
- Added editorial checklist criteria for preserved structure, artifact boundaries, evidence, non-applicability limits, and related-book responsibility boundaries.
- Clarified Appendix D transfer-case limits so cross-domain analogies require auditable boundaries, drift detection, and stop lines.
- Added a pull request template requiring related issue, Copilot review, review-thread completeness, and validation evidence.

## Review Completion Gate

- [x] The PR explains the practical review scope and content-audit judgment.
- [x] Reader-facing changes preserve the English canonical source.
- [x] Japanese drafts from `manuscript/ja/` are not published as-is.
- [x] Theory-to-practice claims name preserved structure and boundaries.
- [x] Theory-to-practice claims name verification evidence and known limits.
- [x] Related-book responsibility boundaries remain explicit.
- [x] GitHub Copilot review was requested.
- [x] Review body, inline comments, and suggestions were all checked.
- [x] Actionable comments were fixed or answered with a non-change rationale.
- [x] Unresolved review threads are confirmed to be 0 before merge.

## Verification

- [x] `git diff --check`
- [x] `npx --yes markdownlint-cli .github/PULL_REQUEST_TEMPLATE.md`
- [x] `npm run qa`
- [x] `npm run build:native`
- [x] `npm run validate-deploy`
- [x] Built-site marker smoke for `/` and `/src/appendices/appendix-d/`
- [x] `check_pr_review_completeness.py --repo itdojp/composable-software-design-book --pr 78 --format json` (`status: ok`, unresolved threads 0)
