### PR TITLE
fix: align the public edition date

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ subtitle: "A Category-Theoretic Guide to Human-AI Boundaries and Verifiable Engi
 description: "A practical guide to governed AI-assisted software delivery using composition, diagrams, and effect boundaries that remain auditable and verifiable."
 author: "ITDO Inc."
 version: "First Edition"
+last_updated: "2026-05-23"
 ---
 
 # Compositional Software Design for Agentic Systems
@@ -144,4 +145,4 @@ See [LICENSE-SCOPE.md](LICENSE-SCOPE.md) for the canonical path boundary and [CO
 
 **Author:** ITDO Inc.  
 **Edition:** First Edition
-**Last updated:** 2026-03-17
+**Last updated:** {{ page.last_updated }}

--- a/scripts/validate-github-pages.js
+++ b/scripts/validate-github-pages.js
@@ -31,6 +31,22 @@ function frontMatterValue(text, key) {
   return match ? match[1].trim() : "";
 }
 
+function isValidCalendarDate(value) {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return false;
+  }
+
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysByMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysByMonth[month - 1];
+}
+
 function flattenNavItems(items) {
   if (!Array.isArray(items)) {
     return [];
@@ -81,7 +97,7 @@ function main() {
     }
 
     const lastUpdated = frontMatterValue(indexText, "last_updated");
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(lastUpdated) || Number.isNaN(Date.parse(`${lastUpdated}T00:00:00Z`))) {
+    if (!isValidCalendarDate(lastUpdated)) {
       errors.push("index.md last_updated must be a valid YYYY-MM-DD date");
     }
     expectRegex(

--- a/scripts/validate-github-pages.js
+++ b/scripts/validate-github-pages.js
@@ -27,8 +27,12 @@ function expectRegex(text, regex, message, errors) {
 }
 
 function frontMatterValue(text, key) {
-  const match = text.match(new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?\\s*$`, "m"));
-  return match ? match[1].trim() : "";
+  const frontMatter = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontMatter) {
+    return "";
+  }
+  const value = frontMatter[1].match(new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?\\s*$`, "m"));
+  return value ? value[1].trim() : "";
 }
 
 function isValidCalendarDate(value) {

--- a/scripts/validate-github-pages.js
+++ b/scripts/validate-github-pages.js
@@ -26,6 +26,11 @@ function expectRegex(text, regex, message, errors) {
   }
 }
 
+function frontMatterValue(text, key) {
+  const match = text.match(new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?\\s*$`, "m"));
+  return match ? match[1].trim() : "";
+}
+
 function flattenNavItems(items) {
   if (!Array.isArray(items)) {
     return [];
@@ -74,6 +79,17 @@ function main() {
     if (/]\((?:\/)?src\/.+\.md\)/.test(indexText)) {
       errors.push("index.md still links to source markdown files instead of published URLs");
     }
+
+    const lastUpdated = frontMatterValue(indexText, "last_updated");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(lastUpdated) || Number.isNaN(Date.parse(`${lastUpdated}T00:00:00Z`))) {
+      errors.push("index.md last_updated must be a valid YYYY-MM-DD date");
+    }
+    expectRegex(
+      indexText,
+      /^\*\*Last updated:\*\*\s+\{\{\s*page\.last_updated\s*\}\}$/m,
+      "public last-updated label must use the canonical index.md front matter value",
+      errors,
+    );
 
     const allNavItems = [
       ...flattenNavItems(nav.additional),


### PR DESCRIPTION
## Summary

- update the public edition date to the fixed-SHA publication revision date, 2026-05-23
- make the index front matter the single source of truth for the rendered date
- extend deployment validation to require a valid canonical date and Liquid-based public label

Closes #80
Parent: itdojp/it-engineer-knowledge-architecture#241

## Verification

- `npm run validate-deploy`
- `npm run qa`
- `npm run build:smoke`
- rendered `_site/index.html` contains `Last updated: 2026-05-23`
- `git diff --check`
