### PR TITLE
fix: align the published UX profile

### DIFF
--- a/_data/navigation.json
+++ b/_data/navigation.json
@@ -15,6 +15,10 @@
       "path": "/src/additional/how-to-use-this-book/"
     },
     {
+      "title": "Concept Map",
+      "path": "/src/additional/concept-map/"
+    },
+    {
       "title": "Who This Book Is For",
       "path": "/src/additional/who-this-book-is-for/"
     }

--- a/book-config.json
+++ b/book-config.json
@@ -171,7 +171,7 @@
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
-      "conceptMap": false,
+      "conceptMap": true,
       "figureIndex": true,
       "legalNotice": false,
       "glossary": true

--- a/book-config.json
+++ b/book-config.json
@@ -165,13 +165,13 @@
     ]
   },
   "ux": {
-    "profile": "A",
+    "profile": "C",
     "modules": {
-      "quickStart": true,
+      "quickStart": false,
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
-      "conceptMap": true,
+      "conceptMap": false,
       "figureIndex": true,
       "legalNotice": false,
       "glossary": true

--- a/index.md
+++ b/index.md
@@ -75,6 +75,7 @@ This English book remains the canonical English manuscript for compositional des
 
 - [Preface](src/additional/preface/)
 - [How to Use This Book](src/additional/how-to-use-this-book/)
+- [Concept Map](src/additional/concept-map/)
 - [Who This Book Is For](src/additional/who-this-book-is-for/)
 
 ## Introduction

--- a/src/additional/concept-map/index.md
+++ b/src/additional/concept-map/index.md
@@ -1,0 +1,44 @@
+---
+layout: book
+title: "Concept Map"
+description: "A reader map connecting responsibility boundaries, categorical structures, delivery controls, and the running example."
+---
+
+# Concept Map
+
+This map shows how the book's category-theoretic vocabulary supports one engineering argument.
+Start with responsibility, preserve structure across representations, make effects explicit, and require evidence before acceptance.
+
+## The main reasoning path
+
+1. **Set responsibility boundaries.**  
+   [Chapter 01](../../chapter-chapter01/) identifies decisions, artifacts, and approvals that must remain accountable.
+2. **Model stable things and allowed transformations.**  
+   [Chapter 02](../../chapter-chapter02/) introduces objects, morphisms, identity, and composition as an interface vocabulary.
+3. **Test whether representations agree.**  
+   [Chapter 03](../../chapter-chapter03/) uses commutative diagrams to expose drift between requirements, architecture, implementation, and evidence.
+4. **Preserve structure while views and systems change.**  
+   [Chapters 04–07](../../chapter-chapter04/) connect translation, view changes, variation, integration, and migration to explicit preservation obligations.
+5. **Separate coordination from effects.**  
+   [Chapter 08](../../chapter-chapter08/) models sequential and parallel coordination, while [Chapter 09](../../chapter-chapter09/) makes tool calls and other effects reviewable.
+6. **Close the loop with acceptance evidence.**  
+   [Chapter 10](../../chapter-chapter10/) applies the complete chain to the policy-gated change-review example.
+
+## Concepts, engineering questions, and evidence
+
+| Concept cluster | Engineering question | Evidence to inspect |
+| --- | --- | --- |
+| Responsibility boundaries | Who may propose, approve, execute, and stop the work? | Decision rights, review plan, approval record |
+| Objects and morphisms | What is stable, and which transformations are allowed? | Interface contract, transformation rule, identity and composition checks |
+| Commutative diagrams | Do independent implementation paths preserve the same claim? | Cross-view trace, diagram check, mismatch report |
+| Functors and natural transformations | What must survive translation or a change of view? | Mapping table, preservation invariant, version-skew check |
+| Products, coproducts, pullbacks, and pushouts | How should requirements, alternatives, integrations, and migrations be composed? | Compatibility assumptions, provenance, conflict policy |
+| Monoidal structure and effects | Which steps may run in parallel, and where can the outside world change? | Workflow graph, effect boundary, retry and rollback rule |
+| End-to-end case study | Can the accepted implementation be traced back to the governed specification? | Specification-to-evidence trace and acceptance gate |
+
+## How to use the map
+
+- If the failure is about authority or approval, begin with Chapter 01 and then move to Chapters 03, 09, and 10.
+- If the failure is model drift, begin with Chapters 02 and 03, then select the relevant translation or integration chapter.
+- If the failure is orchestration or unsafe tool use, begin with Chapters 08 and 09, then verify the complete evidence chain in Chapter 10.
+- Use [Appendix B](../../appendices/appendix-b/) for definitions and the [List of Figures and Tables](../../backmatter/list-of-figures/) for the corresponding visual references.

--- a/src/additional/how-to-use-this-book/index.md
+++ b/src/additional/how-to-use-this-book/index.md
@@ -10,12 +10,13 @@ Most readers come to this book with one urgent pressure, not with a plan to read
 Some need to restore approval discipline around AI-assisted work.
 Others need to repair model drift between specification, design, runtime, and evidence.
 Choose the path that matches the decision pressure in front of you.
+Use the [Concept Map](../concept-map/) when you need to see how responsibility, categorical structures, effect boundaries, and acceptance evidence connect before choosing a path.
 In every case, the book carries the primary reading experience.
 Use the companion repository later when you want to inspect the running example, validators, or file-level realization of a chapter claim.
 
 ## Read it front to back if you are adopting the full method
 
-Read the Preface, this guide, the Introduction, and Chapters 01 through 10 in order.
+Read the Preface, this guide, the Concept Map, the Introduction, and Chapters 01 through 10 in order.
 This path is best when you want one method for architecture, review, orchestration, and evidence rather than a set of local fixes.
 It preserves the intended narrative arc from responsibility boundaries to orchestration, effects, and the full case study.
 


### PR DESCRIPTION
## Summary

- classify the English theory/design book as Profile C
- stop advertising home-page-only Quickstart content as a dedicated module
- add the Profile C-required Concept Map as a dedicated, accessible reader route
- connect the Concept Map from navigation, the public home page, and the Reading Guide
- preserve the dedicated Reading Guide, List of Figures, and Glossary modules

Closes #83
Parent: itdojp/it-engineer-knowledge-architecture#241
Resolves portal UX tracking: itdojp/it-engineer-knowledge-architecture#242

## Verification

- `npm ci --include=dev`
- `npm run check:security` — 0 vulnerabilities
- `npm run qa`
- `npm run build:smoke`
- rendered Concept Map route, home link, navigation, and Reading Guide link
- `git diff --check`
