### PR TITLE
chore: active workflowsをNode.js 24対応Actionへ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -50,7 +50,7 @@ jobs:
         run: bundle exec jekyll build --trace
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -65,4 +65,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Pages workflow: `configure-pages@v5`→`v6`、`setup-node@v4`→`v6`、`upload-pages-artifact@v4`→`v5`、`deploy-pages@v4`→`v5`
- CI workflow: `setup-node@v4`を2箇所とも`v6`へ更新
- Node.js 22、Ruby/Jekyll、permissions、artifact/Pages契約は維持
- active workflowのrepository-managed Node.js 20以前Actionを0件化

## Verification
- actionlint 1.7.12: PASS
- `npm ci`: PASS
- `npm run check:security`: 0 vulnerabilities
- `npm run qa`: PASS
- `npm run build:native`: PASS
- `bundle exec jekyll build`: PASS
- `git diff --check`: PASS
- 対象旧参照: 0 / 新参照: 6

Closes #85
