### PR TITLE
build: support immutable formatter SHA refs

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -32,7 +32,10 @@ ensure_book_formatter() {
 
   if [[ ! -d "${BOOK_FORMATTER_DIR}/.git" ]]; then
     log "Cloning book-formatter into ${BOOK_FORMATTER_DIR}"
-    git clone --depth 1 --branch "${BOOK_FORMATTER_REF}" "${BOOK_FORMATTER_REPO}" "${BOOK_FORMATTER_DIR}"
+    git init --quiet "${BOOK_FORMATTER_DIR}"
+    git -C "${BOOK_FORMATTER_DIR}" remote add origin "${BOOK_FORMATTER_REPO}"
+    git -C "${BOOK_FORMATTER_DIR}" fetch --depth 1 origin "${BOOK_FORMATTER_REF}"
+    git -C "${BOOK_FORMATTER_DIR}" checkout --detach FETCH_HEAD
   else
     log "Updating book-formatter cache"
     git -C "${BOOK_FORMATTER_DIR}" fetch --depth 1 origin "${BOOK_FORMATTER_REF}"


### PR DESCRIPTION
## Summary
- initialize the formatter cache explicitly
- fetch BOOK_FORMATTER_REF and checkout FETCH_HEAD detached
- support branch, tag, and immutable commit SHA without changing the default main ref

## Verification
- bash -n scripts/qa.sh
- default main: bash scripts/qa.sh core
- audited SHA override: BOOK_FORMATTER_REF=69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c bash scripts/qa.sh core
- git diff --check

This PR changes only the fetch contract. The pin update remains in #87 and will use a separate PR.

Closes #89
Parent: itdojp/it-engineer-knowledge-architecture#266
