### PR TITLE
ci: pin audited book-formatter revision

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -7,7 +7,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CACHE_DIR="${ROOT}/.cache"
 BOOK_FORMATTER_DIR="${CACHE_DIR}/book-formatter"
 BOOK_FORMATTER_REPO="${BOOK_FORMATTER_REPO:-https://github.com/itdojp/book-formatter.git}"
-BOOK_FORMATTER_REF="${BOOK_FORMATTER_REF:-main}"
+BOOK_FORMATTER_REF="${BOOK_FORMATTER_REF:-69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c}"
 REPORT_ROOT="${ROOT}/qa-reports"
 REPORT_DIR="${REPORT_ROOT}/${MODE}"
 


### PR DESCRIPTION
## Summary
- change only the default BOOK_FORMATTER_REF from mutable main to audited immutable 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
- rely on the separately merged SHA fetch contract from #89 / PR #90
- keep QA commands, content, dependencies, and build contract unchanged
## Verification
- bash -n scripts/qa.sh
- bash scripts/qa.sh core with the pinned default
- git diff --check
Closes #87
Parent: itdojp/it-engineer-knowledge-architecture#266
