### PR TITLE
docs: separate monad theory from the workflow envelope

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "qa:examples:deep": "python3 scripts/collate-example-traces.py --report-dir qa-reports/examples",
     "qa": "npm run qa:core && npm run qa:examples",
     "check:pushout": "python3 scripts/check-chapter07-pushout.py && python3 scripts/check-chapter07-pushout-regression.py",
+    "check:monad-scope": "python3 scripts/check-chapter09-monad-scope.py && python3 scripts/check-chapter09-monad-scope-regression.py",
     "check:security": "npm audit --include=dev --audit-level=moderate",
     "figures:render": "python3 scripts/render-publication-figures.py",
     "build:native": "bash scripts/check-native-build.sh",

--- a/scripts/check-chapter09-monad-scope-regression.py
+++ b/scripts/check-chapter09-monad-scope-regression.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts/check-chapter09-monad-scope.py"
+FILES = [
+    Path("src/chapter-chapter09/index.md"),
+    Path("src/appendices/appendix-b.md"),
+    Path("src/backmatter/subject-index/index.md"),
+]
+
+
+def replace_text(root: Path, relative: str, old: str, new: str) -> None:
+    path = root / relative
+    content = path.read_text(encoding="utf-8")
+    if old not in content:
+        raise RuntimeError(f"fixture token not found in {relative}: {old!r}")
+    path.write_text(content.replace(old, new, 1), encoding="utf-8")
+
+
+def copy_fixture(destination: Path) -> None:
+    for relative in FILES:
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / relative, target)
+
+
+def run_checker(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--root", str(root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    mutations: list[tuple[str, Callable[[Path], None]]] = [
+        ("remove opening scope", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "one governed-workflow engineering reading", "one general definition")),
+        ("remove endofunctor", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "a monad on a category `C` consists of an endofunctor `T: C -> C`", "a monad packages a computation")),
+        ("remove unit", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "a unit natural transformation `eta: Id_C -> T`", "a way to wrap values")),
+        ("remove multiplication", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "a multiplication natural transformation `mu: T composed with T -> T`", "a way to flatten values")),
+        ("remove associativity", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "the associativity law says", "a practical guideline says")),
+        ("remove return bind equivalence", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "An equivalent programming-oriented presentation uses `return` and `bind`", "A programming analogy mentions return and bind")),
+        ("remove law proof boundary", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "engineering test oracles for the chosen envelope, not proofs of those laws", "proofs of those laws")),
+        ("turn error behavior into law", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "It is not a consequence of the monad laws alone.", "It follows from the monad laws.")),
+        ("remove Kleisli arrow", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "a Kleisli arrow from `A` to `B` is an arrow `A -> T B`", "a Kleisli arrow chains envelopes")),
+        ("make Kleisli arrow accept envelope", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "A next Kleisli arrow still accepts the underlying value `B` and returns `T C`; it does not have type `T B -> T C`.", "The next step must accept that envelope and return another one.")),
+        ("remove Kleisli identity", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "The Kleisli identity on `A` is `eta_A`", "Kleisli composition has an identity")),
+        ("remove Kleisli formula", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "compose as `mu_C composed with T(g) composed with f`", "compose in sequence")),
+        ("make dominant model mandatory", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "not a theorem about monads and not the only valid way to represent multiple effects", "required by monads")),
+        ("remove transformer alternative", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "| Monad transformers or layered composite effects |", "| One combined effect |")),
+        ("remove effect-handler alternative", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "| Effect handlers or capability interfaces |", "| Another envelope |")),
+        ("remove state-machine alternative", lambda root: replace_text(root, "src/chapter-chapter09/index.md", "| Explicit workflow state machine |", "| Another abstraction |")),
+        ("restore simplified Monad glossary", lambda root: replace_text(root, "src/appendices/appendix-b.md", "**Monad.** On a category `C`, an endofunctor `T: C -> C` equipped with a unit natural transformation `eta: Id_C -> T` and a multiplication natural transformation `mu: T composed with T -> T` that satisfy the unit and associativity laws.", "**Monad.** A structure that packages effectful computation so later steps must handle its operational context explicitly.")),
+        ("restore simplified Kleisli glossary", lambda root: replace_text(root, "src/appendices/appendix-b.md", "**Kleisli composition.** The Kleisli category has the same objects as the underlying category and arrows `A -> B` represented by underlying arrows `A -> T B`.", "**Kleisli composition.** The composition rule that chains effectful steps while keeping them inside one explicit effect envelope.")),
+        ("remove Monad index scope", lambda root: replace_text(root, "src/backmatter/subject-index/index.md", "It has a general endofunctor-and-laws definition; the chapter's envelope is one engineering instance.", "It gives the chapter's effect envelope.")),
+        ("remove Kleisli index scope", lambda root: replace_text(root, "src/backmatter/subject-index/index.md", "It composes arrows `A -> T B`; the chapter then adds governed context and evidence obligations.", "It chains governed envelopes.")),
+    ]
+
+    scratch_parent = ROOT / "qa-reports"
+    scratch_parent.mkdir(parents=True, exist_ok=True)
+    failures: list[str] = []
+    negative_passed = 0
+    positive_passed = 0
+    with tempfile.TemporaryDirectory(prefix="issue93-monad-scope-", dir=scratch_parent) as temp_dir:
+        temp_root = Path(temp_dir)
+        baseline = temp_root / "baseline"
+        copy_fixture(baseline)
+        if run_checker(baseline).returncode == 0:
+            positive_passed = 1
+        else:
+            failures.append("positive fixture failed")
+
+        for index, (name, mutate) in enumerate(mutations, start=1):
+            case_root = temp_root / f"case-{index:02d}"
+            copy_fixture(case_root)
+            try:
+                mutate(case_root)
+            except Exception as exc:
+                failures.append(f"{name}: mutation failed: {exc}")
+                continue
+            result = run_checker(case_root)
+            if result.returncode == 0:
+                failures.append(f"{name}: checker accepted the mutated fixture")
+            else:
+                negative_passed += 1
+
+    report = {
+        "contract": "chapter09-monad-scope-regression-v1",
+        "positive": {"passed": positive_passed, "total": 1},
+        "negative": {"passed": negative_passed, "total": len(mutations)},
+        "failures": failures,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=True))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-chapter09-monad-scope.py
+++ b/scripts/check-chapter09-monad-scope.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+CHAPTER_REQUIREMENTS = {
+    "opening scope": "one governed-workflow engineering reading",
+    "scope boundary": "describe this book's design choice rather than a requirement imposed by category theory",
+    "general endofunctor": "a monad on a category `C` consists of an endofunctor `T: C -> C`",
+    "unit natural transformation": "a unit natural transformation `eta: Id_C -> T`",
+    "multiplication natural transformation": "a multiplication natural transformation `mu: T composed with T -> T`",
+    "unit laws": "The unit laws say",
+    "associativity law": "the associativity law says",
+    "return bind equivalence": "An equivalent programming-oriented presentation uses `return` and `bind`",
+    "envelope is an interpretation": "one concrete engineering interpretation of `T`",
+    "left identity": "`return a >>= f` is equivalent to `f a`",
+    "right identity": "`m >>= return` is equivalent to `m`",
+    "bind associativity": "`(m >>= f) >>= g` is equivalent to `m >>= (lambda x: f x >>= g)`",
+    "law proof boundary": "engineering test oracles for the chosen envelope, not proofs of those laws",
+    "error audit scope": "It is not a consequence of the monad laws alone.",
+    "Kleisli arrow": "a Kleisli arrow from `A` to `B` is an arrow `A -> T B`",
+    "Kleisli objects": "The Kleisli category has the same objects as the underlying category.",
+    "Kleisli versus bind": "A next Kleisli arrow still accepts the underlying value `B` and returns `T C`; it does not have type `T B -> T C`.",
+    "bind threading": "Bind or Kleisli composition threads the existing `T B` through that arrow and flattens the result into `T C`.",
+    "Kleisli identity": "The Kleisli identity on `A` is `eta_A`",
+    "Kleisli composition": "compose as `mu_C composed with T(g) composed with f`",
+    "selected M": "this book's chosen instance of `T`",
+    "dominant model choice": "not a theorem about monads and not the only valid way to represent multiple effects",
+    "transformer alternative": "| Monad transformers or layered composite effects |",
+    "effect alternatives": "| Effect handlers or capability interfaces |",
+    "state machine alternative": "| Explicit workflow state machine |",
+    "selection criterion": "failure, authority, and audit requirements rather than a claim that category theory mandates one dominant envelope",
+}
+
+APPENDIX_REQUIREMENTS = {
+    "general monad": "**Monad.** On a category `C`, an endofunctor `T: C -> C` equipped with a unit natural transformation `eta: Id_C -> T` and a multiplication natural transformation `mu: T composed with T -> T`",
+    "monad laws": "`return` and `bind` with left identity, right identity, and associativity",
+    "monad analogy boundary": "one engineering interpretation of this structure, not the general definition",
+    "general Kleisli": "arrows `A -> B` represented by underlying arrows `A -> T B`",
+    "Kleisli result": "Arrows `A -> T B` and `B -> T C` compose into an arrow `A -> T C`",
+    "Kleisli laws": "identities supplied by the unit and associativity supplied by the monad laws",
+    "context boundary": "an additional property of the selected `T`, not part of the definition alone",
+}
+
+INDEX_REQUIREMENTS = {
+    "Monad index scope": "It has a general endofunctor-and-laws definition; the chapter's envelope is one engineering instance.",
+    "Kleisli index scope": "It composes arrows `A -> T B`; the chapter then adds governed context and evidence obligations.",
+}
+
+PROHIBITED_SIMPLIFICATIONS = {
+    "old Monad glossary definition": "**Monad.** A structure that packages effectful computation so later steps must handle its operational context explicitly.",
+    "old Kleisli glossary definition": "**Kleisli composition.** The composition rule that chains effectful steps while keeping them inside one explicit effect envelope.",
+    "monad equals envelope": "monad is an operational envelope by definition",
+    "single model is required": "monads require one dominant effect model",
+    "Kleisli arrow accepts envelope": "The next step must accept that envelope and return another one.",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate Chapter 09 monad scope boundaries.")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    return parser.parse_args()
+
+
+def require_tokens(label: str, content: str, requirements: dict[str, str], errors: list[str]) -> None:
+    for name, token in requirements.items():
+        if token not in content:
+            errors.append(f"{label}: missing {name}: {token!r}")
+
+
+def main() -> int:
+    root = parse_args().root.resolve()
+    paths = {
+        "chapter09": root / "src/chapter-chapter09/index.md",
+        "appendix-b": root / "src/appendices/appendix-b.md",
+        "subject-index": root / "src/backmatter/subject-index/index.md",
+    }
+    errors: list[str] = []
+    content: dict[str, str] = {}
+    for label, path in paths.items():
+        try:
+            content[label] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{label}: cannot read {path.relative_to(root)}: {exc}")
+            content[label] = ""
+
+    require_tokens("chapter09", content["chapter09"], CHAPTER_REQUIREMENTS, errors)
+    require_tokens("appendix-b", content["appendix-b"], APPENDIX_REQUIREMENTS, errors)
+    require_tokens("subject-index", content["subject-index"], INDEX_REQUIREMENTS, errors)
+
+    combined = "\n".join(content.values()).lower()
+    for name, token in PROHIBITED_SIMPLIFICATIONS.items():
+        if token.lower() in combined:
+            errors.append(f"scope: prohibited {name}: {token!r}")
+
+    report = {
+        "contract": "chapter09-monad-scope-v1",
+        "checked_files": [str(path.relative_to(root)) for path in paths.values()],
+        "requirements": {
+            "chapter": len(CHAPTER_REQUIREMENTS),
+            "appendix": len(APPENDIX_REQUIREMENTS),
+            "subject_index": len(INDEX_REQUIREMENTS),
+        },
+        "errors": errors,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=True))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -133,6 +133,12 @@ run_core() {
   log "Running Chapter 07 pushout mutation regression"
   python3 "${ROOT}/scripts/check-chapter07-pushout-regression.py" > "${REPORT_DIR}/check-chapter07-pushout-regression.json"
 
+  log "Running Chapter 09 monad scope check"
+  python3 "${ROOT}/scripts/check-chapter09-monad-scope.py" > "${REPORT_DIR}/check-chapter09-monad-scope.json"
+
+  log "Running Chapter 09 monad scope mutation regression"
+  python3 "${ROOT}/scripts/check-chapter09-monad-scope-regression.py" > "${REPORT_DIR}/check-chapter09-monad-scope-regression.json"
+
   cat > "${REPORT_DIR}/summary.txt" <<EOF
 QA mode: ${MODE}
 Repository root: ${ROOT}
@@ -148,6 +154,8 @@ Reports:
 - check-manuscript-structure.json
 - check-chapter07-pushout.json
 - check-chapter07-pushout-regression.json
+- check-chapter09-monad-scope.json
+- check-chapter09-monad-scope-regression.json
 EOF
 
   log "Core QA completed"

--- a/src/appendices/appendix-b.md
+++ b/src/appendices/appendix-b.md
@@ -80,10 +80,14 @@ See [Chapter 08](../chapter-chapter08/).
 **String diagram.** A diagrammatic notation in which wires represent preserved context or artifacts and boxes represent composed steps.
 See [Chapter 08](../chapter-chapter08/).
 
-**Monad.** A structure that packages effectful computation so later steps must handle its operational context explicitly.
+**Monad.** On a category `C`, an endofunctor `T: C -> C` equipped with a unit natural transformation `eta: Id_C -> T` and a multiplication natural transformation `mu: T composed with T -> T` that satisfy the unit and associativity laws.
+An equivalent programming presentation uses `return` and `bind` with left identity, right identity, and associativity.
+Chapter 09's governed operational envelope is one engineering interpretation of this structure, not the general definition.
 See [Chapter 09](../chapter-chapter09/).
 
-**Kleisli composition.** The composition rule that chains effectful steps while keeping them inside one explicit effect envelope.
+**Kleisli composition.** The Kleisli category has the same objects as the underlying category and arrows `A -> B` represented by underlying arrows `A -> T B`.
+Arrows `A -> T B` and `B -> T C` compose into an arrow `A -> T C`, with identities supplied by the unit and associativity supplied by the monad laws.
+Chapter 09 reads those arrows as governed workflow steps; retaining error, audit, or authority context is an additional property of the selected `T`, not part of the definition alone.
 See [Chapter 09](../chapter-chapter09/).
 
 ## Software design terms

--- a/src/backmatter/subject-index/index.md
+++ b/src/backmatter/subject-index/index.md
@@ -43,9 +43,9 @@ Later mentions should point back to that primary chapter unless the concept is m
 | Execution-Ready Change | [Chapter 04](../../chapter-chapter04/) | `Approved Change`, `effect boundary` | It marks the runtime-facing state reached only after the governed approval meaning is preserved. |
 | Functor | [Chapter 04](../../chapter-chapter04/) | `runtime view`, `reviewer view` | It explains structure-preserving translation across views. |
 | Human review gate | [Chapter 01](../../chapter-chapter01/) | `policy gate`, `Bounded delegation` | It keeps final risk acceptance explicitly human-led. |
-| Kleisli composition | [Chapter 09](../../chapter-chapter09/) | `monad`, `effect boundary` | It chains effectful steps without hiding context and evidence obligations. |
+| Kleisli composition | [Chapter 09](../../chapter-chapter09/) | `monad`, `effect boundary` | It composes arrows `A -> T B`; the chapter then adds governed context and evidence obligations. |
 | Migration plan | [Chapter 07](../../chapter-chapter07/) | `shared boundary`, `replacement plan` | It governs replacement work without blind cutover. |
-| Monad | [Chapter 09](../../chapter-chapter09/) | `Kleisli composition`, `effect boundary` | It gives the chapter's envelope for effectful operational steps. |
+| Monad | [Chapter 09](../../chapter-chapter09/) | `Kleisli composition`, `effect boundary` | It has a general endofunctor-and-laws definition; the chapter's envelope is one engineering instance. |
 | Morphism | [Chapter 02](../../chapter-chapter02/) | `object`, `composition` | It names the transformation that preserves the model's structure. |
 | Object | [Chapter 02](../../chapter-chapter02/) | `morphism`, `identity morphism` | It fixes the stable artifact or state boundary that later reasoning depends on. |
 | Orchestration | [Chapter 08](../../chapter-chapter08/) | `synchronization boundary`, `effect boundary` | It coordinates parallel and sequential work into one governed workflow. |

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -77,7 +77,7 @@ Effect visibility therefore becomes a first-class design requirement rather than
 In general, a monad on a category `C` consists of an endofunctor `T: C -> C`, a unit natural transformation `eta: Id_C -> T`, and a multiplication natural transformation `mu: T composed with T -> T`.
 The unit laws say that applying `mu` after either unit insertion leaves `T` unchanged, and the associativity law says that flattening three nested applications of `T` is independent of grouping.
 An equivalent programming-oriented presentation uses `return` and `bind` subject to left identity, right identity, and associativity.
-These definitions do not require `T` to be an operational envelope or require a computation to return audit context.
+Neither definition makes `T` an operational envelope or requires a computation to return audit context.
 
 This book chooses a governed envelope as one concrete engineering interpretation of `T`.
 Under that interpretation, one computation returns a value together with the operational context needed to continue safely.
@@ -221,7 +221,7 @@ That is ordinary composition plus logging.
 It forces every downstream step to guess which effect already happened.
 The governed envelope chain avoids that guesswork because each step returns value, trace obligation, authority state, and permitted next action together.
 That is the practical payoff of the chapter's Kleisli reading.
-Teams may regroup the chain across services or queues without changing the governed outcome only when the implementation preserves the stated equivalence and the selected effect semantics satisfy the required laws.
+Regrouping the chain across services or queues is safe only when the implementation preserves the stated equivalence and the selected effect semantics satisfy the required laws.
 
 ### Chaining effectful steps safely
 

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -13,11 +13,13 @@ The most expensive workflow defects often begin after the diagram has already st
 A tool call writes state, an override bypasses a gate, or a dispatch step runs before the repository can explain why it was allowed.
 Chapter 09 makes those effects explicit so AI-assisted orchestration remains safe, reviewable, and testable.
 Figure 9.1 and Table 9.1 give the first-reading version of that effect story before the canonical repository artifacts become necessary for deeper inspection.
+This chapter uses monads and Kleisli composition through one governed-workflow engineering reading.
+Unless a passage explicitly states the general definition, the terms `envelope`, `trace obligation`, and `dominant effect model` describe this book's design choice rather than a requirement imposed by category theory.
 
 ## Learning goals
 
 - Distinguish pure artifact reasoning from effectful operational steps that change authority or external state.
-- Read monads and Kleisli composition as workflow envelopes that preserve evidence and next-step obligations across tool calls.
+- Distinguish the general definitions of monads and Kleisli composition from this chapter's governed-envelope reading.
 - Review effect boundaries, retries, and escape hatches without losing the governed approval story.
 
 ## Prerequisites
@@ -72,7 +74,13 @@ Effect visibility therefore becomes a first-class design requirement rather than
 
 ## Monads as operational envelopes
 
-A monad is useful in this book because it gives a disciplined way to say that one computation returns both a value and the operational context needed to continue safely.
+In general, a monad on a category `C` consists of an endofunctor `T: C -> C`, a unit natural transformation `eta: Id_C -> T`, and a multiplication natural transformation `mu: T composed with T -> T`.
+The unit laws say that applying `mu` after either unit insertion leaves `T` unchanged, and the associativity law says that flattening three nested applications of `T` is independent of grouping.
+An equivalent programming-oriented presentation uses `return` and `bind` subject to left identity, right identity, and associativity.
+These definitions do not require `T` to be an operational envelope or require a computation to return audit context.
+
+This book chooses a governed envelope as one concrete engineering interpretation of `T`.
+Under that interpretation, one computation returns a value together with the operational context needed to continue safely.
 The goal is not to force readers into a specific language runtime.
 It is to keep effects attached to their obligations instead of unpacking them into ambient global state.
 
@@ -135,20 +143,31 @@ Even outside software delivery, effectful dispatch is governed only when the emi
 
 ### Reading unit and bind in engineering terms
 
-The unit operation is the move that places a pure artifact into the governed workflow without adding new side effects.
+In the return/bind presentation, `return` places a value of type `A` into `T A`, while `bind` combines a value in `T A` with a function `A -> T B` to produce `T B`.
+Under this chapter's chosen interpretation, the unit operation places a pure artifact into the governed workflow without adding new side effects.
 In practice, that means taking a completed artifact such as `Review Plan` and treating it as the current value inside the review envelope.
 The repository has not yet changed external state merely by acknowledging that artifact.
 
-Bind is the step that consumes the governed context and produces the next governed context.
+The chapter reads bind as the step that consumes the governed context and produces the next governed context.
 If `evaluate-policy` fails, the bind result is not a naked absence of value.
 It is a governed state that still carries trace obligations, route meaning, and a next action such as retry, manual review, or return-for-rework.
 This is the practical reason monadic language helps here.
 It forces the workflow to preserve context across effectful chaining instead of dropping it between tool calls.
-Left identity gives the reader a concrete test.
+
+The formal laws provide three comparison obligations.
+Left identity says `return a >>= f` is equivalent to `f a`.
+Right identity says `m >>= return` is equivalent to `m`.
+Associativity says `(m >>= f) >>= g` is equivalent to `m >>= (lambda x: f x >>= g)`.
+The repository observations below are engineering test oracles for the chosen envelope, not proofs of those laws in a specified category.
+
+Left identity gives the reader one concrete test.
 If the repository places a pure artifact into the envelope and immediately evaluates policy, the governed result should match the direct governed policy evaluation for that same artifact.
 Right identity gives another.
 If the repository rewraps an already governed state, it must not quietly add an approval-like record, create a new trace event, or drop an evidence link.
 Otherwise the supposed bookkeeping step has changed authority or observability and was never neutral.
+
+The requirement that a failure carry trace obligations, route meaning, and a permitted next action belongs to this selected `T` and its workflow contract.
+It is not a consequence of the monad laws alone.
 
 In the running example, every successful bind keeps the same `Change Identity` and current `Plan Revision`.
 Every failing bind yields an outcome the rest of the workflow can still review.
@@ -157,7 +176,8 @@ That is more valuable than the abstract term itself because it turns effect hand
 ## Kleisli composition for agent orchestration
 
 Kleisli composition matters when the output of one effectful step already lives inside the workflow's operational envelope.
-The next step must accept that envelope and return another one.
+A next Kleisli arrow still accepts the underlying value `B` and returns `T C`; it does not have type `T B -> T C`.
+Bind or Kleisli composition threads the existing `T B` through that arrow and flattens the result into `T C`.
 That is exactly what happens in AI-assisted orchestration.
 
 ### Tool calls, prompts, and execution context
@@ -178,6 +198,11 @@ Each step carries the artifact boundary, the effect class, the actor or tool, an
 
 **Formal bridge.**
 
+The Kleisli category has the same objects as the underlying category.
+For a monad `T`, a Kleisli arrow from `A` to `B` is an arrow `A -> T B` in the underlying category.
+The Kleisli identity on `A` is `eta_A`, and arrows `f: A -> T B` and `g: B -> T C` compose as `mu_C composed with T(g) composed with f`.
+The monad laws make that composition associative and give it identities.
+
 ```text
 Effectful chain:
 draft-plan-with-agent : Review Plan -> M Reviewed Plan Revision
@@ -189,14 +214,14 @@ Combined path:
 Review Plan -> M Executable Change Set
 ```
 
-Here `M` is the governed effect envelope that carries trace obligations, authority changes, and permitted next actions together with the value.
+Here `M` is this book's chosen instance of `T`: a governed effect envelope that carries trace obligations, authority changes, and permitted next actions together with the value.
 The chain is safe only when each step returns another governed state instead of dropping context between tool calls.
 A bare artifact chain would let `evaluate-policy` return only `Policy-Evaluated Plan` and ask later steps to infer whether the result was cached, manually overridden, or produced from stale context.
 That is ordinary composition plus logging.
 It forces every downstream step to guess which effect already happened.
 The governed envelope chain avoids that guesswork because each step returns value, trace obligation, authority state, and permitted next action together.
-That is the practical payoff of Kleisli composition.
-Teams may regroup the chain across services or queues without changing the governed outcome that the reviewer and the audit trail must reconstruct.
+That is the practical payoff of the chapter's Kleisli reading.
+Teams may regroup the chain across services or queues without changing the governed outcome only when the implementation preserves the stated equivalence and the selected effect semantics satisfy the required laws.
 
 ### Chaining effectful steps safely
 
@@ -224,6 +249,7 @@ The challenge is to choose one dominant design envelope so the repository has a 
 ### Choosing the dominant effect model
 
 The running example chooses governed review state as the dominant envelope.
+That is an architecture decision for this repository, not a theorem about monads and not the only valid way to represent multiple effects.
 Every important step is evaluated by asking what it means for review, approval, traceability, and execution rights.
 That choice is more practical than choosing a generic error-only or state-only model because the repository's main risk is unauthorized or unreviewable change.
 
@@ -250,6 +276,17 @@ The running example solves this by keeping one reader-facing envelope and surfac
 Prompt context, tool outputs, approval writes, and dispatch results all appear in the trace and acceptance evidence.
 The repository does not need separate public formalisms for each internal helper library.
 It needs one stable operational story.
+
+Other systems may choose a different representation.
+
+| Design choice | Primary benefit | Primary cost or risk |
+| --- | --- | --- |
+| One governed envelope | One review surface for authority, evidence, and next actions | Couples effect semantics and can make the envelope broad |
+| Monad transformers or layered composite effects | Keeps error, state, and I/O concerns separately typed | Ordering, lifting, and interaction rules become part of the design |
+| Effect handlers or capability interfaces | Lets components request effects without fixing one global envelope | Handler scope, runtime support, and evidence capture need explicit governance |
+| Explicit workflow state machine | Makes operational transitions and recovery paths directly visible | Does not automatically provide Kleisli composition or the monad laws |
+
+The selection should follow the system's failure, authority, and audit requirements rather than a claim that category theory mandates one dominant envelope.
 
 That strategy also reduces confusion during review.
 The reviewer asks one question at each boundary.
@@ -296,7 +333,8 @@ It treats specification, design, review, orchestration, and effect evidence as o
 ## Summary
 
 - Effect boundaries matter because tool calls, approval writes, and execution dispatch change what later steps may safely assume.
-- Monadic and Kleisli language is useful when it keeps value, evidence, and authority inside one explicit operational envelope.
+- A monad has a general endofunctor-and-laws definition; the governed envelope is this book's engineering instance, not that definition.
+- Kleisli composition chains arrows `A -> T B`; trace and authority preservation are additional semantics selected for this workflow.
 - Escape hatches, retries, rollback, and audit remain trustworthy only when they emit reviewable evidence at named boundaries.
 
 ## Review prompts


### PR DESCRIPTION
## Summary

- add the general monad definition, return/bind laws, and Kleisli-category definition before applying the governed-workflow reading
- separate Kleisli arrows from bind/composition and distinguish monad laws from error, audit, authority, and trace semantics
- describe the dominant governed envelope as an architecture choice and compare multiple-effect alternatives
- synchronize Appendix B and the subject index
- add fail-closed Chapter 09 scope checks and mutation regressions to Book QA

## Verification

- `npm run check:security` (0 vulnerabilities)
- `npm run check:monad-scope` (positive 1/1; negative 20/20)
- `npm run qa` (formatter/link/Unicode/layout/structure/textlint/placeholders/examples: all pass)
- `npm run build:native`
- `git diff --check`
- independent mathematical/implementation review: initial High/Medium fixed; final blocking/high/medium/low 0

Closes #93
