### PR TITLE
docs: prioritize reader onboarding on the landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,58 +18,45 @@ AI-assisted delivery is moving faster than many teams can explain who may approv
 This book addresses that gap with a compositional design method for governed software delivery.
 It uses category-theoretic ideas selectively so that architecture, review, orchestration, and verification remain one inspectable engineering story.
 
+## Start Here
+
+This book is for software architects, staff engineers, technical leads, platform engineers, and AI product builders who need AI-assisted delivery to remain reviewable when work crosses from proposal to approval and from approval to execution.
+You should be comfortable with software architecture, interface design, and technical review; prior exposure to category theory is helpful but not required.
+Begin with [How to Use This Book](src/additional/how-to-use-this-book/), [Who This Book Is For](src/additional/who-this-book-is-for/), the [Introduction](src/chapter-introduction/), and [Chapter 01](src/chapter-chapter01/) before inspecting repository artifacts.
+
+## What You Will Be Able to Produce
+
+- A responsibility-boundary map that separates delegated drafting, policy evaluation, human approval, execution, and evidence.
+- A set of named objects, transformations, and diagrams that makes preservation claims reviewable across design and runtime views.
+- A synchronized decision packet that keeps request scope, policy results, evidence, and approval authority distinguishable.
+- An effect boundary, execution trace, and acceptance-evidence path that connects an approved change to its operational outcome.
+
+## Fit and Limits
+
+Use this method when AI-assisted work crosses an approval or execution boundary, when multiple views must preserve one design meaning, or when a team must reconstruct why an automated action was allowed.
+The method is not a prompt-optimization guide, a product comparison, or a substitute for domain-specific legal, security, safety, or architecture review.
+Do not force a categorical abstraction onto a local problem when an ordinary interface contract, checklist, or test communicates the obligation more clearly.
+
+## Choose a Reading Path
+
+- **Full method:** read the [Preface](src/additional/preface/), [How to Use This Book](src/additional/how-to-use-this-book/), [Concept Map](src/additional/concept-map/), [Introduction](src/chapter-introduction/), and Chapters 01 through 10 in order.
+- **Governance path:** read the [Introduction](src/chapter-introduction/), [Chapter 01](src/chapter-chapter01/), [Chapter 03](src/chapter-chapter03/), [Chapter 09](src/chapter-chapter09/), and [Chapter 10](src/chapter-chapter10/).
+- **Architecture path:** read the [Introduction](src/chapter-introduction/), Chapters [01](src/chapter-chapter01/), [02](src/chapter-chapter02/), and [03](src/chapter-chapter03/), followed by Chapters [04](src/chapter-chapter04/) through [07](src/chapter-chapter07/).
+- **Delivery path:** read the [Introduction](src/chapter-introduction/), [Chapter 01](src/chapter-chapter01/), [Chapter 08](src/chapter-chapter08/), [Chapter 09](src/chapter-chapter09/), and [Chapter 10](src/chapter-chapter10/).
+
+After the prose establishes the method, use the [minimal example](examples/minimal/policy-gated-change-review/README/) to inspect its smallest artifact chain and the [common running example](examples/common/policy-gated-change-review/README/) to trace the full specification, design, review, implementation, and evidence path.
+
 ## Why This Book Now
 
 Many teams can generate candidate changes, workflow steps, and implementation drafts more quickly than they can govern them.
 That mismatch creates review debt, ambiguous ownership, and weak evidence trails.
-This book is for readers who need AI-assisted engineering to stay explainable at the moment a system crosses from proposal to approval and from approval to execution.
+This book addresses that gap at the points where a system changes approval authority or causes an operational effect.
 
 ## What Makes This Book Different
 
 - It treats AI-assisted delivery as a design problem about boundaries, evidence, and accountability rather than a prompt-optimization problem.
 - It uses category theory as a working design vocabulary for software systems rather than as a stand-alone mathematics survey.
-- It builds one reusable method that connects diagrams, review gates, runtime views, traces, and acceptance evidence across a full engineering workflow.
-
-## What You Will Learn
-
-- Define clear responsibility boundaries between human reviewers and AI-assisted workflows.
-- Model software systems with objects, morphisms, composition, and diagrams.
-- Use universal constructions and effect boundaries to reason about integration, migration, and orchestration.
-- Translate the formal vocabulary into an auditable end-to-end engineering workflow.
-
-## Intended Readers
-
-This book is written for software architects, staff engineers, technical leads, platform engineers, and AI product builders.
-It assumes readers care about both formal rigor and delivery realism.
-It is especially aimed at teams that need to keep approval authority, system meaning, and operational evidence aligned while AI systems participate in delivery.
-
-## Prerequisites
-
-Readers should be comfortable with software architecture, interface design, and technical review.
-Prior exposure to category theory is helpful but not required.
-
-## Reading Guide
-
-Read the Preface, How to Use This Book, Who This Book Is For, the Introduction, and Chapter 01 first if you want the clearest entry into the book's promise and scope.
-Read Chapters 02 through 09 in order if you want the conceptual build-up from composition and diagrams to orchestration and effect boundaries.
-Read Chapter 10 after the core chapters to see the method applied as one end-to-end engineering argument.
-
-## Quickstart
-
-Start with the front matter and the Introduction if you want the book's main promise before any repository inspection.
-Use the [minimal example](examples/minimal/policy-gated-change-review/README/) after that first pass to see the smallest reusable chain of objects, morphisms, and a diagram.
-Continue with the [common running example](examples/common/policy-gated-change-review/README/) when you want to inspect the specification, design, verification, and implementation artifacts that support the chapter arguments.
-
-## Phase 5 Practical-Connection Review Gate
-
-This book should not ask readers to accept a category-theoretic word as practical guidance unless the manuscript also shows what the word preserves in engineering terms.
-For each revised example, reviewer prompt, or architecture claim, check four things: the preserved structure, the artifact or interface boundary, the evidence that would reveal drift, and the limit of the abstraction.
-When those four items are absent, the text should present the idea as intuition rather than as an implementation rule.
-When those four items are present, the text should still identify cases where ordinary engineering review is better than forcing a compositional model.
-
-This gate also protects the relationship with the related Japanese book.
-`categorical-software-design-book` remains a related but independent Japanese reader-facing book with a stronger emphasis on design artifacts, Context Pack use, and GitHub/CI workflows.
-This English book remains the canonical English manuscript for compositional design in agentic systems, so cross-references must clarify responsibility rather than imply a rename, replacement, or translation chain.
+- It connects diagrams, review boundaries, runtime views, traces, and acceptance evidence as one reusable engineering method.
 
 ## Front Matter
 
@@ -121,19 +108,9 @@ This English book remains the canonical English manuscript for compositional des
 - [Publisher Note and ITDO](src/afterword/about-the-author-and-itdo/)
 - [Acknowledgments](src/afterword/acknowledgments/)
 
-## Publication Policy
+## Related Reading
 
-English text is the canonical source for publication.
-Japanese drafts under `manuscript/ja/` are editorial inputs and are not published as-is.
-They are distinct from the separately published Japanese book in `categorical-software-design-book`.
-
-## Related Japanese Book
-
-- `categorical-software-design-book` is a related but independent Japanese book.
-- This English book is not a rename or replacement for that Japanese book.
-- Start here if you want the English-first canonical manuscript and the current part-based composition.
-- Start with the Japanese book if you want a Japanese reader-facing guide focused on software design artifacts for the AI agent era, Context Pack usage, and GitHub/CI-oriented guidance.
-- Related Japanese book: [Public site](https://itdojp.github.io/categorical-software-design-book/) / [Repository](https://github.com/itdojp/categorical-software-design-book)
+For a Japanese reader-facing treatment centered on design artifacts, Context Pack use, and GitHub/CI workflows, see the independent [Categorical Software Design Book](https://itdojp.github.io/categorical-software-design-book/).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:pushout": "python3 scripts/check-chapter07-pushout.py && python3 scripts/check-chapter07-pushout-regression.py",
     "check:monad-scope": "python3 scripts/check-chapter09-monad-scope.py && python3 scripts/check-chapter09-monad-scope-regression.py",
     "check:figure-accessibility": "python3 scripts/check-publication-figure-accessibility.py && python3 scripts/check-publication-figure-accessibility-regression.py",
+    "check:onboarding": "python3 scripts/check-reader-onboarding.py && python3 scripts/check-reader-onboarding-regression.py",
     "check:security": "npm audit --include=dev --audit-level=moderate",
     "figures:render": "python3 scripts/render-publication-figures.py",
     "build:native": "bash scripts/check-native-build.sh",

--- a/project-management/editorial-checklist.md
+++ b/project-management/editorial-checklist.md
@@ -48,6 +48,7 @@
 
 ## Phase 5 Practical-Connection Review Gate
 
+- This is a maintainer-only editorial gate; keep it in project-management material rather than placing it in the public landing-page onboarding flow.
 - A theory-to-practice claim names the preserved structure or invariant before it asks the reader to trust a formal term.
 - The claim points to a concrete artifact boundary, interface, type, checklist, test, trace, or evidence bundle that would carry the preserved structure.
 - The revision states how a reviewer would detect drift, such as by checking a diagram claim, traceability row, schema field, test result, or review prompt.

--- a/project-management/publishing-setup.md
+++ b/project-management/publishing-setup.md
@@ -15,6 +15,13 @@ There is no `docs/_config.yml` in the current setup.
 - baseurl: `/composable-software-design-book`
 - repository: `itdojp/composable-software-design-book`
 
+## Canonical Source and Related-Book Boundary
+
+- English text in this repository is the canonical publication source for *Compositional Software Design for Agentic Systems*.
+- Japanese drafts under `manuscript/ja/` are editorial inputs and are not published as-is.
+- `categorical-software-design-book` is a related but independent Japanese reader-facing book, not a rename, replacement, or translation chain for this book.
+- Maintainer cross-references must preserve that ownership boundary; the public landing page should expose only the reader-relevant route to the related book.
+
 ## Layout and Defaults
 
 All published pages use the `book` layout.

--- a/scripts/check-reader-onboarding-regression.py
+++ b/scripts/check-reader-onboarding-regression.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CACHE_DIR = ROOT / ".cache"
+CHECKER = ROOT / "scripts" / "check-reader-onboarding.py"
+FILES = (
+    "index.md",
+    "src/additional/how-to-use-this-book/index.md",
+    "project-management/editorial-checklist.md",
+    "project-management/publishing-setup.md",
+)
+
+
+def copy_fixture(destination: Path) -> None:
+    for relative in FILES:
+        source = ROOT / relative
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def run_checker(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--root", str(root)],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def replace_once(root: Path, relative: str, old: str, new: str) -> None:
+    path = root / relative
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        raise RuntimeError(f"mutation source not found in {relative}: {old}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def main() -> int:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    mutations = (
+        ("remove Start Here", "index.md", "## Start Here", "## Reader Notes"),
+        ("remove target audience", "index.md", "software architects, staff engineers, technical leads, platform engineers, and AI product builders", "software teams"),
+        ("make category theory required", "index.md", "prior exposure to category theory is helpful but not required", "prior exposure to category theory is required"),
+        ("remove book-first sequence", "index.md", "before inspecting repository artifacts", "while inspecting repository artifacts"),
+        ("remove How to Use route", "index.md", "[How to Use This Book](src/additional/how-to-use-this-book/)", "How to Use This Book"),
+        ("remove first chapter route", "index.md", "[Chapter 01](src/chapter-chapter01/)", "Chapter 01"),
+        ("remove responsibility outcome", "index.md", "A responsibility-boundary map", "A general overview"),
+        ("remove decision outcome", "index.md", "A synchronized decision packet", "A review document"),
+        ("remove applicability", "index.md", "Use this method when AI-assisted work crosses an approval or execution boundary", "This method is broadly useful"),
+        ("remove non-applicability", "index.md", "The method is not a prompt-optimization guide, a product comparison, or a substitute", "The method complements"),
+        ("remove ordinary alternative", "index.md", "Do not force a categorical abstraction", "Prefer a categorical abstraction"),
+        ("remove governance path", "index.md", "**Governance path:**", "**Selected chapters:**"),
+        ("remove delivery path", "index.md", "**Delivery path:**", "**Operational chapters:**"),
+        ("remove minimal example", "index.md", "[minimal example](examples/minimal/policy-gated-change-review/README/)", "minimal example"),
+        ("expose Phase 5 on top", "index.md", "## Front Matter", "## Phase 5 Practical-Connection Review Gate\n\nInternal review text.\n\n## Front Matter"),
+        ("expose publication policy on top", "index.md", "## Related Reading", "## Publication Policy\n\nEnglish text is the canonical source for publication.\n\n## Related Reading"),
+        ("drift top metadata", "index.md", 'layout: book', 'layout: default'),
+        ("remove How to Use book-first contract", "src/additional/how-to-use-this-book/index.md", "the book carries the primary reading experience", "the repository carries the primary reading experience"),
+        ("remove maintainer-only relocation", "project-management/editorial-checklist.md", "maintainer-only editorial gate", "editorial gate"),
+        ("remove non-applicability editorial check", "project-management/editorial-checklist.md", "non-applicability condition", "application condition"),
+        ("remove canonical source relocation", "project-management/publishing-setup.md", "English text in this repository is the canonical publication source", "English text is a publication source"),
+        ("collapse related-book boundary", "project-management/publishing-setup.md", "related but independent Japanese reader-facing book", "Japanese edition"),
+        ("remove reader-only public route", "project-management/publishing-setup.md", "public landing page should expose only the reader-relevant route", "public landing page should expose the repository workflow"),
+    )
+
+    failures: list[str] = []
+    passed_negative = 0
+    with tempfile.TemporaryDirectory(prefix="reader-onboarding-", dir=CACHE_DIR) as temp_dir:
+        temp_root = Path(temp_dir)
+        baseline = temp_root / "baseline"
+        copy_fixture(baseline)
+        positive = run_checker(baseline)
+        if positive.returncode != 0:
+            failures.append(f"positive fixture failed: {positive.stdout}{positive.stderr}")
+
+        for index, (name, relative, old, new) in enumerate(mutations, start=1):
+            fixture = temp_root / f"case-{index:02d}"
+            copy_fixture(fixture)
+            try:
+                replace_once(fixture, relative, old, new)
+            except Exception as exc:
+                failures.append(f"{name}: mutation failed: {exc}")
+                continue
+            result = run_checker(fixture)
+            if result.returncode == 0:
+                failures.append(f"{name}: checker accepted the mutated fixture")
+            else:
+                passed_negative += 1
+
+    report = {
+        "positive_passed": 0 if failures and failures[0].startswith("positive fixture") else 1,
+        "positive_total": 1,
+        "negative_detected": passed_negative,
+        "negative_total": len(mutations),
+        "failures": failures,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-reader-onboarding.py
+++ b/scripts/check-reader-onboarding.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_ROOT = Path(__file__).resolve().parents[1]
+
+ONBOARDING_HEADINGS = (
+    "## Start Here",
+    "## What You Will Be Able to Produce",
+    "## Fit and Limits",
+    "## Choose a Reading Path",
+    "## Why This Book Now",
+    "## What Makes This Book Different",
+    "## Front Matter",
+)
+
+TOP_REQUIREMENTS = {
+    "audience": "software architects, staff engineers, technical leads, platform engineers, and AI product builders",
+    "prerequisite": "prior exposure to category theory is helpful but not required",
+    "book-first sequence": "before inspecting repository artifacts",
+    "how-to-use link": "[How to Use This Book](src/additional/how-to-use-this-book/)",
+    "reader-fit link": "[Who This Book Is For](src/additional/who-this-book-is-for/)",
+    "introduction link": "[Introduction](src/chapter-introduction/)",
+    "first chapter link": "[Chapter 01](src/chapter-chapter01/)",
+    "responsibility outcome": "A responsibility-boundary map",
+    "diagram outcome": "A set of named objects, transformations, and diagrams",
+    "decision outcome": "A synchronized decision packet",
+    "evidence outcome": "An effect boundary, execution trace, and acceptance-evidence path",
+    "applicability": "Use this method when AI-assisted work crosses an approval or execution boundary",
+    "non-applicability": "The method is not a prompt-optimization guide, a product comparison, or a substitute",
+    "ordinary alternative": "Do not force a categorical abstraction",
+    "full path": "**Full method:**",
+    "governance path": "**Governance path:**",
+    "architecture path": "**Architecture path:**",
+    "delivery path": "**Delivery path:**",
+    "minimal example": "[minimal example](examples/minimal/policy-gated-change-review/README/)",
+    "common example": "[common running example](examples/common/policy-gated-change-review/README/)",
+    "related-reader route": "[Categorical Software Design Book](https://itdojp.github.io/categorical-software-design-book/)",
+}
+
+FORBIDDEN_TOP_TEXT = (
+    "Phase 5 Practical-Connection Review Gate",
+    "## Publication Policy",
+    "English text is the canonical source for publication",
+    "manuscript/ja/",
+    "GitHub Copilot",
+    "unresolved review threads",
+    "maintainer-only",
+)
+
+SECTION_REQUIREMENTS = {
+    "## Start Here": (
+        TOP_REQUIREMENTS["audience"],
+        TOP_REQUIREMENTS["prerequisite"],
+        TOP_REQUIREMENTS["book-first sequence"],
+        TOP_REQUIREMENTS["how-to-use link"],
+        TOP_REQUIREMENTS["reader-fit link"],
+        TOP_REQUIREMENTS["introduction link"],
+        TOP_REQUIREMENTS["first chapter link"],
+    ),
+    "## What You Will Be Able to Produce": (
+        TOP_REQUIREMENTS["responsibility outcome"],
+        TOP_REQUIREMENTS["diagram outcome"],
+        TOP_REQUIREMENTS["decision outcome"],
+        TOP_REQUIREMENTS["evidence outcome"],
+    ),
+    "## Fit and Limits": (
+        TOP_REQUIREMENTS["applicability"],
+        TOP_REQUIREMENTS["non-applicability"],
+        TOP_REQUIREMENTS["ordinary alternative"],
+    ),
+    "## Choose a Reading Path": (
+        TOP_REQUIREMENTS["full path"],
+        TOP_REQUIREMENTS["governance path"],
+        TOP_REQUIREMENTS["architecture path"],
+        TOP_REQUIREMENTS["delivery path"],
+        TOP_REQUIREMENTS["minimal example"],
+        TOP_REQUIREMENTS["common example"],
+    ),
+}
+
+HOW_TO_REQUIREMENTS = (
+    "the book carries the primary reading experience",
+    "## Read it front to back if you are adopting the full method",
+    "## Start with the governance path if your urgent problem is authority and review",
+    "## Start with the architecture path if your urgent problem is model integrity",
+    "## Start with the delivery path if your urgent problem is orchestration",
+    "Do not reverse the dependency.",
+)
+
+EDITORIAL_REQUIREMENTS = (
+    "## Phase 5 Practical-Connection Review Gate",
+    "maintainer-only editorial gate",
+    "rather than placing it in the public landing-page onboarding flow",
+    "preserved structure or invariant",
+    "non-applicability condition",
+)
+
+PUBLISHING_REQUIREMENTS = (
+    "## Canonical Source and Related-Book Boundary",
+    "English text in this repository is the canonical publication source",
+    "Japanese drafts under `manuscript/ja/` are editorial inputs",
+    "related but independent Japanese reader-facing book",
+    "not a rename, replacement, or translation chain",
+    "public landing page should expose only the reader-relevant route",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate reader-first public landing-page onboarding.")
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT, help="Repository root to validate.")
+    return parser.parse_args()
+
+
+def read(path: Path, errors: list[str]) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"cannot read {path}: {exc}")
+        return ""
+
+
+def validate_top(text: str, errors: list[str]) -> None:
+    heading_positions: list[int] = []
+    for heading in ONBOARDING_HEADINGS:
+        if text.count(heading) != 1:
+            errors.append(f"public top must contain exactly one heading: {heading}")
+            continue
+        heading_positions.append(text.index(heading))
+    if len(heading_positions) == len(ONBOARDING_HEADINGS) and heading_positions != sorted(heading_positions):
+        errors.append("public top reader-onboarding headings are out of order")
+
+    body_headings = re.findall(r"^#{1,2} .+$", text, re.MULTILINE)
+    if len(body_headings) < 2 or body_headings[1] != "## Start Here":
+        errors.append("Start Here must be the first H2 after the book title")
+
+    for label, token in TOP_REQUIREMENTS.items():
+        if token not in text:
+            errors.append(f"public top is missing {label}: {token}")
+    for token in FORBIDDEN_TOP_TEXT:
+        if token in text:
+            errors.append(f"public top exposes maintainer/editorial process text: {token}")
+
+    for heading, tokens in SECTION_REQUIREMENTS.items():
+        start = text.find(heading)
+        if start < 0:
+            continue
+        following = text[start + len(heading) :]
+        next_heading = re.search(r"^## ", following, re.MULTILINE)
+        section = following[: next_heading.start()] if next_heading else following
+        for token in tokens:
+            if token not in section:
+                errors.append(f"{heading} is missing reader-onboarding content: {token}")
+
+    front_matter = text.split("---", 2)[1] if text.startswith("---") and text.count("---") >= 2 else ""
+    required_metadata = {
+        'title: "Compositional Software Design for Agentic Systems"',
+        'subtitle: "A Category-Theoretic Guide to Human-AI Boundaries and Verifiable Engineering"',
+        'description: "A practical guide to governed AI-assisted software delivery using composition, diagrams, and effect boundaries that remain auditable and verifiable."',
+        'layout: book',
+    }
+    for token in required_metadata:
+        if token not in front_matter:
+            errors.append(f"public top front matter drifted: {token}")
+
+
+def validate_tokens(name: str, text: str, tokens: tuple[str, ...], errors: list[str]) -> None:
+    for token in tokens:
+        if token not in text:
+            errors.append(f"{name} is missing contract text: {token}")
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+    errors: list[str] = []
+    paths = {
+        "public top": root / "index.md",
+        "How to Use": root / "src" / "additional" / "how-to-use-this-book" / "index.md",
+        "editorial checklist": root / "project-management" / "editorial-checklist.md",
+        "publishing setup": root / "project-management" / "publishing-setup.md",
+    }
+    content = {name: read(path, errors) for name, path in paths.items()}
+    validate_top(content["public top"], errors)
+    validate_tokens("How to Use", content["How to Use"], HOW_TO_REQUIREMENTS, errors)
+    validate_tokens("editorial checklist", content["editorial checklist"], EDITORIAL_REQUIREMENTS, errors)
+    validate_tokens("publishing setup", content["publishing setup"], PUBLISHING_REQUIREMENTS, errors)
+
+    report = {
+        "checked_files": [str(path.relative_to(root)) for path in paths.values()],
+        "onboarding_headings": list(ONBOARDING_HEADINGS),
+        "top_requirements": len(TOP_REQUIREMENTS),
+        "forbidden_process_terms": len(FORBIDDEN_TOP_TEXT),
+        "errors": errors,
+        "status": "ok" if not errors else "failed",
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -145,6 +145,12 @@ run_core() {
   log "Running publication figure accessibility mutation regression"
   python3 "${ROOT}/scripts/check-publication-figure-accessibility-regression.py" > "${REPORT_DIR}/check-publication-figure-accessibility-regression.json"
 
+  log "Running reader onboarding contract check"
+  python3 "${ROOT}/scripts/check-reader-onboarding.py" > "${REPORT_DIR}/check-reader-onboarding.json"
+
+  log "Running reader onboarding mutation regression"
+  python3 "${ROOT}/scripts/check-reader-onboarding-regression.py" > "${REPORT_DIR}/check-reader-onboarding-regression.json"
+
   cat > "${REPORT_DIR}/summary.txt" <<EOF
 QA mode: ${MODE}
 Repository root: ${ROOT}
@@ -164,6 +170,8 @@ Reports:
 - check-chapter09-monad-scope-regression.json
 - check-publication-figure-accessibility.json
 - check-publication-figure-accessibility-regression.json
+- check-reader-onboarding.json
+- check-reader-onboarding-regression.json
 EOF
 
   log "Core QA completed"


### PR DESCRIPTION
## Summary

- put audience, prerequisites, outcomes, fit/limits, and reading paths before the public table of contents
- remove maintainer-only Phase 5 and publication policy details from the public landing flow
- preserve those contracts in the editorial checklist and publishing setup
- add fail-closed reader-onboarding QA and mutation regression

## Verification

- `npm run check:security` (0 vulnerabilities)
- `npm run validate-deploy`
- `npm run check:onboarding` (positive 1/1, negative 23/23)
- `npm run qa`
- `npm run build:native`
- built landing-page heading/marker inspection
- Python compile checks
- `git diff --check`

Closes #95
